### PR TITLE
Update default build container to publish dev/testing/release tags

### DIFF
--- a/workflow-templates/build-sw-container.yml
+++ b/workflow-templates/build-sw-container.yml
@@ -29,7 +29,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - id: generate-tag-list
+    - name: Generate tag list
+      id: generate-tag-list
       env:
         REPO: ${{ matrix.repo }}
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}

--- a/workflow-templates/build-sw-container.yml
+++ b/workflow-templates/build-sw-container.yml
@@ -8,18 +8,35 @@ on:
       - dispatch-build
 
 jobs:
-  build:
+  make-date-tag:
     runs-on: ubuntu-latest
     if: startsWith(github.repository, 'opensciencegrid/')
+    outputs:
+      dtag: ${{ steps.mkdatetag.outputs.dtag }}
     steps:
-    - uses: actions/checkout@v2
-
     - name: make date tag
       id: mkdatetag
       run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
 
-    - id: format-docker-repo
-      run: echo "::set-output name=repo-name::${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}"
+  build:
+    runs-on: ubuntu-latest
+    needs: [make-date-tag]
+    if: startsWith(github.repository, 'opensciencegrid/')
+    strategy:
+      fail-fast: False
+      matrix:
+        repo: ['development', 'testing', 'release']
+    steps:
+    - uses: actions/checkout@v2
+
+    - id: generate-tag-list
+      env:
+        REPO: ${{ matrix.repo }}
+        TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
+      run: |
+        docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
+        tag_list=$docker_repo:$REPO,$docker_repo:$REPO-$TIMESTAMP
+        echo "::set-output name=taglist::$tag_list"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -34,5 +51,5 @@ jobs:
       uses: docker/build-push-action@v2.2.0
       with:
         push: true
-        tags: "${{ steps.format-docker-repo.outputs.repo-name }}:fresh,\
-          ${{ steps.format-docker-repo.outputs.repo-name }}:${{ steps.mkdatetag.outputs.dtag }}"
+        build-args: BASE_YUM_REPO=${{ matrix.repo }}
+        tags: "${{ steps.generate-tag-list.outputs.taglist }}"


### PR DESCRIPTION
(SOFTWARE-4457)

This repo contains templates for when people add workflows to OSG repos through the GitHub UI. I figure any new container repos should just start off with the new tagging policy.