### PR TITLE
Update ways of getting PYTHONPATH and filelist, change v1 to v2

### DIFF
--- a/workflow-templates/python-linters.yaml
+++ b/workflow-templates/python-linters.yaml
@@ -8,19 +8,19 @@ jobs:
     outputs:
       filelist: ${{ steps.python-files.outputs.filelist }}
     steps:
-
+    - uses: actions/checkout@v2
     - id: python-files
-      run:
-        echo "::set-output name=filelist::$(find . -type f -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} +)"
+      run: |
+        echo "::set-output name=filelist::$(find . -type f -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + | tr '\n' ' ')"
 
   pylint:
     runs-on: ubuntu-latest
     needs: [python-files]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.6
 
@@ -38,18 +38,19 @@ jobs:
         pip --cache-dir ~/pip-cache install pylint
     - name: Run Pylint
       env:
-        PYTHONPATH: $PYTHONPATH:$PWD/src/htcondorce
         PYTHON_FILES: ${{ needs.python-files.outputs.filelist }}
-      run: |
+      run: | # Change PYTHONPATH for different repo
+        export PYTHONPATH=$PYTHONPATH:$PWD/src/scripts
         pylint --errors-only $PYTHON_FILES
+  
   flake8:
     runs-on: ubuntu-latest
     needs: [python-files]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.6
 
@@ -67,7 +68,7 @@ jobs:
         pip --cache-dir ~/pip-cache install flake8
     - name: Run flake8
       env:
-        PYTHONPATH: $PYTHONPATH:$PWD/src/htcondorce
         PYTHON_FILES: ${{ needs.python-files.outputs.filelist }}
-      run: |
+      run: | # Change PYTHONPATH for different repo
+        export PYTHONPATH=$PYTHONPATH:$PWD/src/scripts
         flake8 --select F $PYTHON_FILES


### PR DESCRIPTION
Change filelist from separated by newlines to separated by whitespace.
PYTHONPATH set in env field is not recognized by GHA, so it needs to be exported and used.
All `actions/setup-python` and `actions/checkout` are updated from v1 to v2.